### PR TITLE
Share console across progress bars

### DIFF
--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -13,7 +13,7 @@ from nhentai.cmdline import cmd_parser, banner, write_config
 from nhentai.parser import doujinshi_parser, search_parser, legacy_search_parser, print_doujinshi, favorites_parser
 from nhentai.doujinshi import Doujinshi
 from nhentai.downloader import Downloader, CompressedDownloader
-from nhentai.logger import logger
+from nhentai.logger import logger, console
 from nhentai.constant import BASE_URL
 from nhentai.utils import generate_html, generate_doc, generate_main_html, generate_metadata, \
     paging, check_cookie, signal_handler, DB, move_to_folder
@@ -139,6 +139,9 @@ def run_downloads(options, doujinshi_ids):
             TextColumn("[cyan]{task.completed}/{task.total}"),
             TextColumn("favorites"),
             TimeRemainingColumn(),
+            console=console,
+            refresh_per_second=10,
+            transient=False,
         )
         if options.favorites and options.is_download and doujinshi_ids
         else nullcontext()

--- a/nhentai/downloader.py
+++ b/nhentai/downloader.py
@@ -11,7 +11,7 @@ import aiofiles
 from urllib.parse import urlparse
 from rich.progress import Progress, BarColumn, TextColumn, TimeRemainingColumn
 from nhentai import constant
-from nhentai.logger import logger
+from nhentai.logger import logger, console
 from nhentai.utils import Singleton, async_request
 
 
@@ -59,6 +59,9 @@ class Downloader(Singleton):
             TextColumn("[cyan]{task.completed}/{task.total}"),
             TextColumn("pages"),
             TimeRemainingColumn(),
+            console=console,
+            refresh_per_second=10,
+            transient=False,
         ) as progress:
             download_task = progress.add_task("[green]Downloading", total=len(download_tasks))
 


### PR DESCRIPTION
### Motivation
- Ensure all `rich` progress bars render to the same shared console to avoid interleaved or inconsistent output.  
- Keep progress bars persistent and updating in-place with a reasonable refresh rate so they remain visible during downloads.

### Description
- Import the shared `console` from `nhentai.logger` in `nhentai/command.py` and `nhentai/downloader.py` and update the imports to `from nhentai.logger import logger, console`.
- Pass `console=console` into the `Progress(...)` constructor used for the favorites progress in `run_downloads` (`nhentai/command.py`).
- Pass `console=console`, `refresh_per_second=10`, and `transient=False` into the `Progress(...)` used in `Downloader.fiber` (`nhentai/downloader.py`) to keep bars visible and update at a higher refresh rate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cd22be234832fb1218f880ed906a1)